### PR TITLE
[PALADIN #02] add balance check to liquidate

### DIFF
--- a/src/PPFX.sol
+++ b/src/PPFX.sol
@@ -651,6 +651,7 @@ contract PPFX is IPPFX, Context {
     function _liquidate(address user, string memory marketName, uint256 amount, uint256 fee) internal {
         bytes32 market = _marketHash(marketName);
         require(marketExists[market], "Provided market does not exists");
+        require(userTradingBalance[user][market] >= amount + fee, "Insufficient trading balance to liquidate");
         _deductUserTradingBalance(user, market, userTradingBalance[user][market]);
         userFundingBalance[user] += amount;
         require(usdt.balanceOf(address(this)) >= fee, "Liquidate: Insufficient usdt balance to transfer fee to insurance");


### PR DESCRIPTION
Fix audit Issue 02, missing a check to ensure user trading balance of the user is sufficient to cover the fee and remaining amount.