### PR TITLE
[PALADIN #03] add minimum amount check when opening & reducing order

### DIFF
--- a/src/IPPFX.sol
+++ b/src/IPPFX.sol
@@ -15,6 +15,7 @@ interface IPPFX {
     event NewUSDT(address indexed newUSDTAddress);
     event NewMarketAdded(bytes32 market, string marketName);
     event NewWithdrawalWaitTime(uint256 newWaitTime);
+    event NewMinimumOrderAmount(uint256 newMinOrderAmt);
     
     event NewUserTradingVault(address newTradingVaultAddr);
     event NewUserFundingVault(address newFundingVaultAddr);

--- a/test/PPFX.t.sol
+++ b/test/PPFX.t.sol
@@ -27,7 +27,8 @@ contract PPFXTest is Test {
             treasury,
             insurance,
             IERC20(address(usdt)),
-            5
+            5,
+            1
         );
     }
 


### PR DESCRIPTION
Add minimum order amount when opening & reducing order to prevent position is lower than fee to pay for closing / liquidating position